### PR TITLE
Remove --ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,19 @@ typescriptify [command]
 
 Commands:
   typescriptify setup    Set your project up to support TypeScript.
-  typescriptify convert  Convert Flow-typed files to TypeScript.                              
-  typescriptify fix      Use the TypeScript compiler to identify and fix errors.             
+  typescriptify convert  Convert Flow-typed files to TypeScript.
+  typescriptify fix      Use the TypeScript compiler to identify and fix errors.
 
 Options:
-  --version  Show version number                                                                                                                           
-  --help     Show help                                                                                                                                     
+  --version  Show version number
+  --help     Show help
 
 Examples:
   typescriptify <setup,convert,fix> --help                                         Show usage instructions for a specific command.
   typescriptify convert --path .                                                   Run the codemod in dry-run mode.
   typescriptify convert --path src/ test/                                          Run the codemod on multiple paths.
-  typescriptify convert --path . --ignore flow_typed/                              Ignore files from conversion.
   typescriptify convert --path ./src --format csv --output ./migration-report.csv  Generate a CSV migration report.
-  typescriptify convert --path . --write --delete                                  Fully convert a project to TypeScript, 
+  typescriptify convert --path . --write --delete                                  Fully convert a project to TypeScript,
                                                                                    writing files and deleting Flow files.
   typescriptify convert --path . --write --target=./dist                           Specify a directory to output the TypeScript files.
   typescriptify fix --autoSuppressErrors --removeUnused                            Remove unused ts-expect-errors, and add any for current errors.
@@ -119,7 +118,7 @@ These types are defined in `./flow.d.ts`, and you'll need to do some setup to ma
 ## 📌 Advanced usage
 <details>
   <summary>Click to expand!</summary>
-  
+
 ### Automatically suppressing TypeScript errors
 After conversion, there will likely be a number of errors in the converted TypeScript files. These errors can be the result of pre-existing issues in the Flow code, issues with the installed types, or issues with the codemod. For many conversions, the number of errors may be challenging to fix before merging. The auto suppression feature will run the TypeScript compiler against your converted code, and add [ts-expect-error](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#ts-ignore-or-ts-expect-error) annotations that suppress errors. This allows you to suppress the errors to get a passing type check, and then fix the errors in future changes. If you fix an error that fixes other errors, you can use the `removeUnused` flag to automatically remove unused suppressions.
 
@@ -196,4 +195,3 @@ If you have questions about this code or our migration, you can reach out to mem
     <td align="center"><a href="https://github.com/alunny"><img src="https://avatars.githubusercontent.com/u/48361?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Andrew Lunny</b></sub></a><br /></td>
   </tr>
 </table>
-

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "flow": "^0.2.3",
     "flow-bin": "^0.162.0",
     "fs-extra": "^8.1.0",
-    "ignore": "^5.1.9",
     "jest": "^26.0.0",
     "jest-junit": "^12.0.0",
     "patch-package": "^6.4.7",

--- a/src/cli/arguments.ts
+++ b/src/cli/arguments.ts
@@ -46,8 +46,6 @@ export interface ConvertCommandCliArgs extends SharedCommandCliArgs {
   handleSpreadReactProps: boolean;
   // Don't replace all $ with .
   keepPrivateTypes: boolean;
-  // Array of directories or files to ignore
-  ignore: Array<string>;
   // Force all file extensions to end in tsx
   forceTSX: boolean;
   // Skip renaming @noflow annotated files

--- a/src/cli/yargs.ts
+++ b/src/cli/yargs.ts
@@ -37,10 +37,6 @@ export const parseCommands = (
       "Run the codemod on multiple paths."
     )
     .example(
-      "$0 convert --path . --ignore flow_typed/ ",
-      "Ignore files from conversion."
-    )
-    .example(
       "$0 convert --path ./src --format csv --output ./migration-report.csv",
       "Generate a CSV migration report."
     )
@@ -152,11 +148,6 @@ export const parseCommands = (
             type: "array",
             default: ["."],
             describe: "Path to source files for conversion.",
-          })
-          .option("ignore", {
-            type: "array",
-            default: [],
-            describe: "Directories or files to ignore.",
           })
           .option("format", {
             alias: "f",

--- a/src/runner/find-flow-files.ts
+++ b/src/runner/find-flow-files.ts
@@ -8,7 +8,6 @@
 
 import path from "path";
 import fs from "fs-extra";
-import ignore from "ignore";
 import MigrationReporter from "./migration-reporter";
 
 /**
@@ -31,7 +30,6 @@ export type FlowFileList = Array<{ filePath: string; fileType: FlowFileType }>;
  */
 export function findFlowFilesAsync(
   rootDirectory: string,
-  ignoredDirectories: Array<string>,
   reporter: MigrationReporter
 ): Promise<FlowFileList> {
   return new Promise((_resolve, _reject) => {
@@ -41,8 +39,6 @@ export function findFlowFilesAsync(
     let waiting = 0;
     // All the valid file paths that we have found.
     const filePaths: FlowFileList = [];
-    // Track ignored files
-    const ig = ignore().add(ignoredDirectories);
 
     // Begin the recursion!
     processDirectory(rootDirectory, reporter);
@@ -89,11 +85,6 @@ export function findFlowFilesAsync(
       waiting++;
       // Get the file path for this file.
       const filePath = path.join(directory, fileName);
-      // Check whether file should be skipped
-      if (ig.ignores(filePath)) {
-        done();
-        return;
-      }
       // Get the stats for the file.
       fs.lstat(filePath, (error, stats) => {
         if (error) {

--- a/src/runner/run-primary-async.ts
+++ b/src/runner/run-primary-async.ts
@@ -40,9 +40,7 @@ export async function runPrimaryAsync(options: ConvertCommandCliArgs) {
   for (const p of options.path) {
     const isDirectory = fs.lstatSync(p).isDirectory();
     if (isDirectory) {
-      filePromises.push(
-        findFlowFilesAsync(p, options.ignore, filePathReporter)
-      );
+      filePromises.push(findFlowFilesAsync(p, filePathReporter));
     } else {
       logger.info("Path to convert is a file, only converting single file.");
       const filePromise: Promise<FlowFileList> = Promise.resolve([

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,11 +2580,6 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-ignore@^5.1.9:
-  version "5.1.9"
-  resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
-  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
-
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"


### PR DESCRIPTION
[sc199790]

The `--ignore` option does not seem to work on our codebase. Instead of using it, we will just point the codemod at specific directories.